### PR TITLE
feat: extension is now 'deployable' without pre-installed Apache POI …

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,6 @@ mvn clean package
 
 ## Installation to Polarion
 
-> [!WARNING]
-> Before using this extension you have to ensure that the current Polarion instance contains Apache POI Polarion Bundle (for more information please check [ch.sbb.polarion.thirdparty.bundles](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.thirdparty.bundles)):
-> `<polarion_home>/polarion/extensions/ch.sbb.polarion.thirdparty.bundles.org.apache.poi/eclipse/plugins/org.apache.poi-<version>.jar` should be installed in Polarion.
-
-
 To install the extension to Polarion, file `ch.sbb.polarion.extension.excel-importer-<version>.jar`
 should be copied to `<polarion_home>/polarion/extensions/ch.sbb.polarion.extension.excel-importer/eclipse/plugins`
 It can be done manually or automated using maven build:
@@ -28,6 +23,10 @@ mvn clean install -P install-to-local-polarion
 For automated installation with maven env variable `POLARION_HOME` should be defined and point to folder where Polarion is installed.
 
 Changes only take effect after restart of Polarion.
+
+## Apache POI Polarion Bundle
+Latest Polarion installations have relatively old version of Apache POI so it is recommended to use Apache POI Polarion Bundle (for more information please check [ch.sbb.polarion.thirdparty.bundles](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.thirdparty.bundles)):
+its artifact must be placed to `<polarion_home>/polarion/extensions/ch.sbb.polarion.thirdparty.bundles.org.apache.poi/eclipse/plugins/org.apache.poi-<version>.jar`
 
 ## Polarion configuration
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>6.7.0</version>
+        <version>7.0.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.excel-importer</artifactId>
@@ -46,10 +46,11 @@
     <properties>
         <maven-jar-plugin.Extension-Context>excel-importer</maven-jar-plugin.Extension-Context>
         <maven-jar-plugin.Automatic-Module-Name>ch.sbb.polarion.extension.excel_importer</maven-jar-plugin.Automatic-Module-Name>
+        <maven-jar-plugin.Discover-Base-Package>ch.sbb.polarion.extension.excel_importer</maven-jar-plugin.Discover-Base-Package>
 
         <web.app.name>${maven-jar-plugin.Extension-Context}</web.app.name>
 
-        <ch.sbb.polarion.thirdparty.bundles.org.apache.poi.version>1.3.0</ch.sbb.polarion.thirdparty.bundles.org.apache.poi.version>
+        <apache-poi.version>4.1.0</apache-poi.version>
 
         <!--suppress UnresolvedMavenProperty -->
         <markdown2html-maven-plugin.failOnError>${env.MARKDOWN2HTML_MAVEN_PLUGIN_FAIL_ON_ERROR}</markdown2html-maven-plugin.failOnError>
@@ -63,9 +64,15 @@
         </dependency>
 
         <dependency>
-            <groupId>ch.sbb.polarion.thirdparty.bundles</groupId>
-            <artifactId>org.apache.poi</artifactId>
-            <version>${ch.sbb.polarion.thirdparty.bundles.org.apache.poi.version}</version>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi</artifactId>
+            <version>${apache-poi.version}</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.poi</groupId>
+            <artifactId>poi-ooxml</artifactId>
+            <version>${apache-poi.version}</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/configuration/ApachePoiVersionStatusProvider.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/configuration/ApachePoiVersionStatusProvider.java
@@ -1,0 +1,21 @@
+package ch.sbb.polarion.extension.excel_importer.configuration;
+
+import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatus;
+import ch.sbb.polarion.extension.generic.configuration.ConfigurationStatusProvider;
+import ch.sbb.polarion.extension.generic.configuration.Status;
+import ch.sbb.polarion.extension.generic.util.Discoverable;
+import org.apache.poi.Version;
+import org.jetbrains.annotations.NotNull;
+
+@Discoverable
+@SuppressWarnings("unused")
+public class ApachePoiVersionStatusProvider extends ConfigurationStatusProvider {
+
+    private static final String APACHE_POI_NAME = "Apache POI";
+    private static final String VERSION_LABEL_TEMPLATE = "Version %s";
+
+    @Override
+    public @NotNull ConfigurationStatus getStatus(@NotNull Context context) {
+        return new ConfigurationStatus(APACHE_POI_NAME, Status.OK, VERSION_LABEL_TEMPLATE.formatted(Version.getVersion()));
+    }
+}

--- a/src/main/resources/META-INF/MANIFEST.MF
+++ b/src/main/resources/META-INF/MANIFEST.MF
@@ -9,5 +9,6 @@ Require-Bundle: com.polarion.portal.tomcat,
  io.swagger,
  org.springframework.spring-core,
  org.springframework.spring-web,
- ch.sbb.polarion.thirdparty.bundles.org.apache.poi
+ ch.sbb.polarion.thirdparty.bundles.org.apache.poi;resolution:=optional
 Export-Package: ch.sbb.polarion.extension.excel_importer
+Import-Package: org.apache.poi,org.apache.poi.ooxml,org.apache.poi.openxml4j.exceptions,org.apache.poi.ss.usermodel,org.apache.poi.ss.util,org.apache.poi.xssf.usermodel


### PR DESCRIPTION
…Bundle

Refs: #33

### Proposed changes

It would be nice to reduce the number of required bundles. Extension must work properly even on old Apache POI version which already included into Polarion installation.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
