### PR TITLE
fix: unknown values must raise error for boolean fields instead of be…

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
@@ -136,10 +136,9 @@ public class ImportService {
     @VisibleForTesting
     boolean ensureValidValue(String fieldId, Object value, Set<FieldMetadata> fieldMetadataSet) {
         FieldMetadata fieldMetadata = getFieldMetadataForField(fieldMetadataSet, fieldId);
-        if (FieldType.BOOLEAN.getType().equals(fieldMetadata.getType())) {
-            if (!(value instanceof String) || !("true".equalsIgnoreCase((String) value) || "false".equalsIgnoreCase((String) value))) {
-                throw new IllegalArgumentException(String.format("'%s' isn't a valid boolean value", value == null ? "" : value));
-            }
+        if (FieldType.BOOLEAN.getType().equals(fieldMetadata.getType()) &&
+                (!(value instanceof String) || !("true".equalsIgnoreCase((String) value) || "false".equalsIgnoreCase((String) value)))) {
+            throw new IllegalArgumentException(String.format("'%s' isn't a valid boolean value", value == null ? "" : value));
         }
         return true;
     }


### PR DESCRIPTION
…ing treated as 'false'

Refs: #43

### Proposed changes

Raise error when user provides unknown value for boolean fields instead of treating it as 'false' value.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
