### PR TITLE
fix: preserve line breaks during html table export

### DIFF
--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ExportServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ExportServiceTest.java
@@ -1,6 +1,8 @@
 package ch.sbb.polarion.extension.excel_importer.service;
 
 import org.intellij.lang.annotations.Language;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Element;
 import org.junit.jupiter.api.Test;
 
 import java.nio.charset.StandardCharsets;
@@ -126,6 +128,60 @@ class ExportServiceTest {
                 IllegalArgumentException.class,
                 () -> exportService.exportHtmlTable("TestSheet", null)
         );
+    }
+
+    @Test
+    void testExtractSimpleText() {
+        Element element = Jsoup.parseBodyFragment("Simple text").body();
+        assertEquals("Simple text", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractSimpleTagText() {
+        Element element = Jsoup.parseBodyFragment("<span>Simple text</span>").body().child(0);
+        assertEquals("Simple text", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractTextWithBr() {
+        Element element = Jsoup.parseBodyFragment("<span>Line 1<br>Line 2<br>Line 3</span>").body().child(0);
+        assertEquals("Line 1\nLine 2\nLine 3", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractTextWithBrVariants() {
+        Element element = Jsoup.parseBodyFragment("<span>First line<br/>Second line<br />Third line</span>").body().child(0);
+        assertEquals("First line\nSecond line\nThird line", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractNestedElements() {
+        Element element = Jsoup.parseBodyFragment("<span>Outer <b>Bold</b> Text<br>Next Line</span>").body().child(0);
+        assertEquals("Outer Bold Text\nNext Line", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractDeeplyNestedElements() {
+        Element element = Jsoup.parseBodyFragment("<div><div>Parent <span>Child <b>Bold</b></span></div><br>New Line</div>").body().child(0);
+        assertEquals("Parent Child Bold\nNew Line", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractEmptyElement() {
+        Element element = Jsoup.parseBodyFragment("<div></div>").body().child(0);
+        assertEquals("", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractOnlyBrElements() {
+        Element element = Jsoup.parseBodyFragment("<span><br><br><br></span>").body().child(0);
+        assertEquals("", exportService.extractTextWithLineBreaks(element));
+    }
+
+    @Test
+    void testExtractBrElementsInTheMiddle() {
+        Element element = Jsoup.parseBodyFragment("<span>Some<br><br><br>text</span>").body().child(0);
+        assertEquals("Some\n\n\ntext", exportService.extractTextWithLineBreaks(element));
     }
 
 }


### PR DESCRIPTION
### Proposed changes

We have to preserve line breaks during html table export.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
