### PR TITLE
feat: ability to set row height on html table export

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ $excelTool.init()
 <table id="users-table">
    <tr>
       <th style="font-weight: bold">Name</th>
-      <th xlsx_width="300">Phone number</th>
+      <th xlsx-width="300">Phone number</th>
    </tr>
-   <tr>
+   <tr style="color: #22CC66" xlsx-height="200">
       <td>John Doe</td>
       <td>555-12-34</td>
    </tr>
@@ -100,16 +100,17 @@ In the above case extension generates the file `UsersData.xlsx` with the data fr
 
 Supported custom attributes:
 
-| Attribute    | Description                                                                    |
-|--------------|--------------------------------------------------------------------------------|
-| xlsx_width   | Width for the column (approx. value in pixels). Can be put on 'th' tags only.  |
+| Attribute   | Description                                                                   |
+|-------------|-------------------------------------------------------------------------------|
+| xlsx-width  | Width for the column (approx. value in pixels). Can be put on 'th' tags only. |
+| xlsx-height | Height for the row (approx. value in pixels). Can be put on 'tr' tags only.   |
 
 Supported style properties:
 
 | Property         | Description                                           |
 |------------------|-------------------------------------------------------|
-| color            | Font color                                            |
-| background-color | Cell background color                                 |
+| color            | Font color (supported format: #RRGGBB)                |
+| background-color | Cell background color (supported format: #RRGGBB)     |
 | font-weight      | Bold font when value = 'bold' or integer value >= 700 |
 
 ## Known issues

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ExportService.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ExportService.java
@@ -30,8 +30,8 @@ public class ExportService {
         StyleContext styleContext = new StyleContext(workbook);
         for (int i = 0; i < cellsData.size(); i++) {
             Row row = sheet.createRow(i);
-            row.setHeight((short) -1); // workaround to auto size height
             List<CellData> cells = cellsData.get(i);
+            row.setHeight(StyleUtil.getRowHeightForCell(cells.get(0)));
 
             for (int j = 0; j < cells.size(); j++) {
                 CellData data = cells.get(j);
@@ -40,12 +40,7 @@ public class ExportService {
                 setCellValue(cell, data, workbook);
 
                 if (data.isHeader()) {
-                    String columnWidth = data.getAttrs().get().get(StyleUtil.CUSTOM_ATTR_COLUMN_WIDTH);
-                    if (!StringUtils.isEmpty(columnWidth)) {
-                        sheet.setColumnWidth(j, (int) StyleUtil.CHARACTER_WIDTH_TO_PX_MULTIPLIER * Integer.parseInt(columnWidth));
-                    } else {
-                        sheet.autoSizeColumn(j);
-                    }
+                    StyleUtil.adjustColumnWidth(j, data, sheet);
                 }
             }
         }

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/htmltable/StyleUtil.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/htmltable/StyleUtil.java
@@ -2,6 +2,7 @@ package ch.sbb.polarion.extension.excel_importer.service.htmltable;
 
 import com.polarion.core.util.StringUtils;
 import lombok.experimental.UtilityClass;
+import org.apache.poi.ss.usermodel.Sheet;
 import org.jsoup.nodes.Node;
 
 import java.util.HashMap;
@@ -14,6 +15,7 @@ import java.util.stream.Stream;
 public class StyleUtil {
 
     public static final float CHARACTER_WIDTH_TO_PX_MULTIPLIER = 36.64f;
+    public static final float POINT_TO_PX_MULTIPLIER = 15f;
 
     public static final String CSS_PROPERTY_COLOR = "color";
     public static final String CSS_PROPERTY_BG_COLOR = "background-color";
@@ -25,10 +27,15 @@ public class StyleUtil {
             CSS_PROPERTY_FONT_WEIGHT
     );
 
-    public static final String CUSTOM_ATTR_COLUMN_WIDTH = "xlsx_width";
+    public static final String CUSTOM_ATTR_COLUMN_WIDTH = "xlsx-width";
+    public static final String CUSTOM_ATTR_ROW_HEIGHT = "xlsx-height";
+
+    public static final short COLUMN_WIDTH_AUTO = -1; // we do not use this value, we call autoSizeColumn() method instead
+    public static final short ROW_HEIGHT_AUTO = (short) -1; // '-1' leads to auto size height
 
     public static final List<String> CUSTOM_ATTRS = List.of(
-            CUSTOM_ATTR_COLUMN_WIDTH
+            CUSTOM_ATTR_COLUMN_WIDTH,
+            CUSTOM_ATTR_ROW_HEIGHT
     );
 
     public Map<String, String> parseStyleAttribute(String attrValue) {
@@ -68,6 +75,25 @@ public class StyleUtil {
         } catch (Exception e) {
             return false;
         }
+    }
+
+    public static void adjustColumnWidth(int columnIndex, CellData data, Sheet sheet) {
+        int columnWidth = StyleUtil.getColumnWidthForCell(data);
+        if (StyleUtil.COLUMN_WIDTH_AUTO == columnWidth) {
+            sheet.autoSizeColumn(columnIndex);
+        } else {
+            sheet.setColumnWidth(columnIndex, columnWidth);
+        }
+    }
+
+    public int getColumnWidthForCell(CellData data) {
+        String columnWidthAttrValue = data.getAttrs().get().get(StyleUtil.CUSTOM_ATTR_COLUMN_WIDTH);
+        return !StringUtils.isEmpty(columnWidthAttrValue) ? (int) (CHARACTER_WIDTH_TO_PX_MULTIPLIER * Integer.parseInt(columnWidthAttrValue)) : COLUMN_WIDTH_AUTO;
+    }
+
+    public short getRowHeightForCell(CellData data) {
+        String rowHeightAttrValue = data.getAttrs().row().get(StyleUtil.CUSTOM_ATTR_ROW_HEIGHT);
+        return (short) (!StringUtils.isEmpty(rowHeightAttrValue) ? (POINT_TO_PX_MULTIPLIER * Short.parseShort(rowHeightAttrValue)) : ROW_HEIGHT_AUTO);
     }
 
 }

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/StyleUtilTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/StyleUtilTest.java
@@ -82,11 +82,11 @@ class StyleUtilTest {
         CellData attrExistsCellData = CellData.builder().attrs(new CellConfig(Map.of(), Map.of(), Map.of("xlsx-width", "100"))).build();
         Sheet sheetMock = mock(Sheet.class);
         StyleUtil.adjustColumnWidth(5, noAttrCellData, sheetMock);
-        verify(sheetMock, times(0)).setColumnWidth(eq(5), eq(3664));
-        verify(sheetMock, times(1)).autoSizeColumn(eq(5));
+        verify(sheetMock, times(0)).setColumnWidth(5, 3664);
+        verify(sheetMock, times(1)).autoSizeColumn(5);
         StyleUtil.adjustColumnWidth(7, attrExistsCellData, sheetMock);
-        verify(sheetMock, times(1)).setColumnWidth(eq(7), eq(3664));
-        verify(sheetMock, times(0)).autoSizeColumn(eq(7));
+        verify(sheetMock, times(1)).setColumnWidth(7, 3664);
+        verify(sheetMock, times(0)).autoSizeColumn(7);
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/StyleUtilTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/StyleUtilTest.java
@@ -13,7 +13,6 @@ import java.util.Map;
 import java.util.stream.Stream;
 
 import static org.junit.jupiter.api.Assertions.*;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.*;
 
 class StyleUtilTest {


### PR DESCRIPTION
### Proposed changes

User must have the ability to set row height on html table export.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
