### PR TITLE
feat: skip processing of missing work items when ID was used for link…

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -492,17 +492,14 @@
         "properties": {
           "baseUrl": {
             "description": "Returns the base URL constructed with the extension context",
-            "example": "/polarion/pdf-exporter",
             "type": "string"
           },
           "extensionContext": {
             "description": "The extension context used as a base for URL construction",
-            "example": "pdf-exporter",
             "type": "string"
           },
           "restUrl": {
             "description": "Returns the REST API URL constructed with the extension context",
-            "example": "/polarion/pdf-exporter/rest",
             "type": "string"
           },
           "swaggerUiUrl": {
@@ -595,6 +592,18 @@
             "description": "List of IDs that were created during the import process",
             "items": {
               "description": "List of IDs that were created during the import process",
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "log": {
+            "description": "Text log generated during import process",
+            "type": "string"
+          },
+          "skippedIds": {
+            "description": "List of IDs that were skipped during the import process",
+            "items": {
+              "description": "List of IDs that were skipped during the import process",
               "type": "string"
             },
             "type": "array"

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportResult.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportResult.java
@@ -20,4 +20,10 @@ public class ImportResult {
 
     @Schema(description = "List of IDs that were unchanged during the import process")
     private List<String> unchangedIds;
+
+    @Schema(description = "List of IDs that were skipped during the import process")
+    private List<String> skippedIds;
+
+    @Schema(description = "Text log generated during import process")
+    private String log;
 }

--- a/src/main/resources/META-INF/hivemodule.xml
+++ b/src/main/resources/META-INF/hivemodule.xml
@@ -38,7 +38,7 @@
                   pageUrl="/polarion/excel-importer-admin/pages/mappings.jsp?scope=$scope$"
                   projectScope="true"
                   projectGroupScope="false"
-                  repositoryScope="true"/>
+                  repositoryScope="false"/>
 
         <extender id="import-file"
                   name="Import File"
@@ -47,7 +47,7 @@
                   pageUrl="/polarion/excel-importer-admin/pages/import_file.jsp?scope=$scope$"
                   projectScope="true"
                   projectGroupScope="false"
-                  repositoryScope="true"/>
+                  repositoryScope="false"/>
     </contribution>
 
     <contribution configuration-id="com.polarion.xray.webui.customNavigationExtenders">

--- a/src/main/resources/webapp/excel-importer-admin/js/modules/import_file.js
+++ b/src/main/resources/webapp/excel-importer-admin/js/modules/import_file.js
@@ -41,11 +41,19 @@ function importFile() {
         body: formData,
         onOk: (response) => {
             const result = JSON.parse(response);
+            const log = String(result.log);
             ctx.showActionAlert({
                 containerId: 'action-success',
-                message: `File successfully imported. Created: ${result.createdIds.length}, updated: ${result.updatedIds.length}, unchanged: ${result.unchangedIds.length}.`,
+                message: `File successfully imported. Created: ${result.createdIds.length}, updated: ${result.updatedIds.length}, unchanged: ${result.unchangedIds.length}, skipped: ${result.skippedIds.length}.
+                &nbsp;<a href="#" data-filename="${generateLogFileName()}" id="download-log-link">(log)</a>`,
                 hideAlertByTimeout: false
             });
+
+            ctx.onClick('download-log-link', () => {
+                    ctx.downloadBlob(new Blob([log], {type: "text/plain"}), ctx.getElementById("download-log-link").dataset.filename);
+                }
+            );
+
             disableAllButtons(false);
         },
         onError: (status, responseText) => {
@@ -65,6 +73,20 @@ function getProjectIdFromScope() {
         return ctx.scope.match(regExp)[1];
     }
     return '';
+}
+
+function generateLogFileName() {
+    const importFileName = ctx.getElementById("file-name").textContent;
+    const baseName = importFileName.replace(/\.[^/.]+$/, "") // remove file extension
+        .replace(/[^a-zA-Z0-9-_]/g, "").replace(/\s+/g, "_"); // sanitize the name
+    const now = new Date(); // append current date and time in the format YYYY_MM_DD_HH_MM_SS
+    const formattedDate = now.getFullYear() + "_" +
+        String(now.getMonth() + 1).padStart(2, "0") + "_" +
+        String(now.getDate()).padStart(2, "0") + "_" +
+        String(now.getHours()).padStart(2, "0") + "_" +
+        String(now.getMinutes()).padStart(2, "0") + "_" +
+        String(now.getSeconds()).padStart(2, "0");
+    return `${baseName}_${formattedDate}.txt`;
 }
 
 function disableAllButtons(disable) {

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
@@ -149,18 +149,18 @@ class ImportServiceTest {
             map.put("D", null);
 
             //test using disabled 'overwriteWithEmpty'
-            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of()),
+            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "New work item 'testId' is being created"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(map), generateSettings(false)));
             verify(workItem, times(0)).setCustomField(eq("nullPossible"), eq(null));
 
             //'overwriteWithEmpty' enabled but existing value is null therefore is no update expected
-            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of()),
+            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "New work item 'testId' is being created"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(map), generateSettings(true)));
             verify(workItem, times(0)).setCustomField(eq("nullPossible"), eq(null));
 
             //'overwriteWithEmpty' enabled and existing value differs
             lenient().when(workItem.getCustomField(eq("nullPossible"))).thenReturn("someExistingValue");
-            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of()),
+            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "New work item 'testId' is being created"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(map), generateSettings(true)));
             verify(workItem, times(1)).setCustomField(eq("nullPossible"), eq(null));
         }
@@ -231,12 +231,8 @@ class ImportServiceTest {
                     "Expected IllegalArgumentException thrown, but it didn't");
             assertEquals("WorkItem id can only be imported if it is used as Link Column.", exception.getMessage());
 
-            // test importing wi with id as link column but imported wi has id that does not exist
-            exception = assertThrows(IllegalArgumentException.class,
-                    () -> new ImportService(polarionServiceExt).processFile(project, List.of(mapOne), generateSettingsForIdImport(true)),
-                    "Expected IllegalArgumentException thrown, but it didn't");
-            assertEquals("If id is used as Link Column, no new Work Items can be created via import.", exception.getMessage());
-
+            assertEquals(new ImportResult(List.of(), List.of(), List.of(), List.of("a1"), "No work item found by ID 'a1'. Since the 'id' is used as the 'Link Column', new work item creation is impossible"),
+                    new ImportService(polarionServiceExt).processFile(project, List.of(mapOne), generateSettingsForIdImport(true)));
 
             Map<String, Object> mapTwo = new HashMap<>(); // imported id cell is empty
             mapTwo.put("A", "");
@@ -254,7 +250,7 @@ class ImportServiceTest {
             mapThree.put("B", "newTitle");
 
             // test importing wi with id as link column and imported wi has same id as existing wi
-            assertEquals(new ImportResult(List.of(), List.of(), List.of("testId")),
+            assertEquals(new ImportResult(List.of(), List.of(), List.of("testId"), List.of(), "No changes were made to 'testId'"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(mapThree), generateSettingsForIdImport(true)));
 
         }


### PR DESCRIPTION
…ing, ability to download import log file

Refs: #86

### Proposed changes

We should not to terminate the whole import operation when no work item found by ID. Instead we must mark this specific action as 'skipped'. Also we must give the user ability to download import log file containing more precise infromation about import process.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [ ] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [ ] If applicable, I have added tests that prove my fix is effective or that my feature works
- [ ] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
