### PR TITLE
feat: mapping on different workitem types

### DIFF
--- a/docs/openapi.json
+++ b/docs/openapi.json
@@ -629,6 +629,9 @@
       },
       "Option": {
         "properties": {
+          "iconUrl": {
+            "type": "string"
+          },
           "key": {
             "type": "string"
           },

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
@@ -51,6 +51,7 @@ public class ImportService {
         return TransactionalExecutor.executeInWriteTransaction(transaction -> processWorkItemIds(workItemIds, trackerProject, workItemType, xlsxData, settings));
     }
 
+    @SuppressWarnings("java:S3776") // ignore cognitive complexity complaint
     private ImportResult processWorkItemIds(Set<String> workItemIds, ITrackerProject project, ITypeOpt workItemType, @NotNull List<Map<String, Object>> xlsxData, ExcelSheetMappingSettingsModel settings) {
         List<String> updatedIds = new ArrayList<>();
         List<String> createdIds = new ArrayList<>();

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
@@ -59,38 +59,38 @@ public class ImportService {
         List<String> log = new ArrayList<>();
 
         String identifierFieldId = settings.getColumnsMapping().get(settings.getLinkColumn());
-        List<IWorkItem> foundWorkItems = polarionServiceExt.findWorkItemsById(project.getId(), settings.getDefaultWorkItemType(), identifierFieldId, workItemIds);
+        List<IWorkItem> foundWorkItems = polarionServiceExt.findWorkItemsById(project.getId(), identifierFieldId, workItemIds);
 
         for (Map<String, Object> columnMappingRecord : xlsxData) {
             Object idValue = columnMappingRecord.get(settings.getLinkColumn());
-            IWorkItem workItem = foundWorkItems.stream()
-                    .filter(findWorkItemByFieldValue(identifierFieldId, idValue))
-                    .findFirst()
-                    .orElse(null);
-            boolean createNew = workItem == null;
-            if (createNew) { //WorkItem not found - create a new one
+            String idString = String.valueOf(idValue);
+            List<String> logEntries = new ArrayList<>();
+            List<IWorkItem> workItems = foundWorkItems.stream().filter(findWorkItemByFieldValue(identifierFieldId, idValue)).toList();
+            if (workItems.isEmpty()) { //WorkItem not found - create a new one
                 if (!identifierFieldId.equals("id")) {
-                    workItem = polarionServiceExt.createWorkItem(project, workItemType);
+                    IWorkItem createdWorkItem = polarionServiceExt.createWorkItem(project, workItemType);
+                    fillWorkItemFields(createdWorkItem, columnMappingRecord, settings, identifierFieldId);
+                    createdWorkItem.save();
+                    logEntries.add("new work item '%s' is being created".formatted(createdWorkItem.getId()));
+                    createdIds.add(createdWorkItem.getId());
                 } else {
-                    String idString = String.valueOf(idValue);
                     skippedIds.add(idString);
-                    log.add("No work item found by ID '%s'. Since the 'id' is used as the 'Link Column', new work item creation is impossible".formatted(idString));
-                    continue;
+                    logEntries.add("no work item found by ID '%s'. Since the 'id' is used as the 'Link Column', new work item creation is impossible".formatted(idString));
+                }
+            } else {
+                for (IWorkItem workItem : workItems) {
+                    fillWorkItemFields(workItem, columnMappingRecord, settings, identifierFieldId);
+                    if (!workItem.isModified()) {
+                        logEntries.add("no changes were made to '%s'".formatted(workItem.getId()));
+                        unchangedIds.add(workItem.getId());
+                    } else {
+                        logEntries.add("the data was updated for '%s'".formatted(workItem.getId()));
+                        updatedIds.add(workItem.getId());
+                    }
+                    workItem.save();
                 }
             }
-            fillWorkItemFields(workItem, columnMappingRecord, settings, identifierFieldId); //set fields values
-            boolean isWorkItemUnchanged = !workItem.isModified(); // maybe isModified doesn't work on a new WI before save?
-            workItem.save();
-            if (createNew) {
-                log.add("New work item '%s' is being created".formatted(workItem.getId()));
-                createdIds.add(workItem.getId());
-            } else if (isWorkItemUnchanged) {
-                log.add("No changes were made to '%s'".formatted(workItem.getId()));
-                unchangedIds.add(workItem.getId());
-            } else {
-                log.add("The data was updated for '%s'".formatted(workItem.getId()));
-                updatedIds.add(workItem.getId());
-            }
+            log.add(idString + ": " + String.join(", ", logEntries));
         }
 
         return ImportResult.builder()

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/PolarionServiceExt.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/PolarionServiceExt.java
@@ -16,6 +16,7 @@ import com.polarion.subterra.base.data.identification.IContextId;
 import com.polarion.subterra.base.data.model.internal.PrimitiveType;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Set;
 import java.util.TreeSet;
@@ -65,8 +66,8 @@ public class PolarionServiceExt extends ch.sbb.polarion.extension.generic.servic
     }
 
     @SuppressWarnings({"unchecked", "rawtypes"})
-    public List<IWorkItem> findWorkItemsById(String projectId, String workItemType, String identifierCustomFieldId, Set<String> ids) {
-        String query = "project.id:" + projectId + " AND type:" + workItemType + " AND (" + ids.stream()
+    public List<IWorkItem> findWorkItemsById(String projectId, String identifierCustomFieldId, Collection<String> ids) {
+        String query = "project.id:" + projectId + " AND (" + ids.stream()
                 .map(i -> identifierCustomFieldId + ":" + i)
                 .collect(Collectors.joining(" OR ")) + ")";
 

--- a/src/main/resources/webapp/excel-importer-admin/pages/mappings.jsp
+++ b/src/main/resources/webapp/excel-importer-admin/pages/mappings.jsp
@@ -87,7 +87,7 @@
             <td colspan="2"><input id="overwrite" type="checkbox"><label for="overwrite" title="Determines whether or not an empty value from the imported excel file should overwrite (and thus delete) an existing value of the work item field.">Overwrite with empty values</label></td>
         </tr>
     </table>
-    <h2 class="align-left">Workitem Type</h2>
+    <h2 class="align-left">Workitem Type To Create</h2>
     <div id="workitem-types-container">
         <label for="wi-types">Import rows as: </label><select class="fs-14" id="wi-types"></select>
     </div>
@@ -112,8 +112,9 @@
             <h3>General Settings</h3>
             <p>This section contains inputs with the Excel sheet name (<code>Sheet1</code> by default) and the row number (1 by default) to import data from.</p>
 
-            <h3>Workitem Type</h3>
+            <h3>Workitem Type To Create</h3>
             <p>This section contains a combobox with workitem types available for the current project.</p>
+            <p>In case if there is no workitem found by given identifier - it will be created using this type. This means that the extension can update any type in the current project (not only the one selected in this combobox).</p>
 
             <h3>Column Name To Workitem Field Mapping</h3>
             <p>This section contains comboboxes for mapping Excel column names to Polarion workitem fields.</p>

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
@@ -149,18 +149,18 @@ class ImportServiceTest {
             map.put("D", null);
 
             //test using disabled 'overwriteWithEmpty'
-            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "New work item 'testId' is being created"),
+            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "b1: new work item 'testId' is being created"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(map), generateSettings(false)));
             verify(workItem, times(0)).setCustomField(eq("nullPossible"), eq(null));
 
             //'overwriteWithEmpty' enabled but existing value is null therefore is no update expected
-            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "New work item 'testId' is being created"),
+            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "b1: new work item 'testId' is being created"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(map), generateSettings(true)));
             verify(workItem, times(0)).setCustomField(eq("nullPossible"), eq(null));
 
             //'overwriteWithEmpty' enabled and existing value differs
             lenient().when(workItem.getCustomField(eq("nullPossible"))).thenReturn("someExistingValue");
-            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "New work item 'testId' is being created"),
+            assertEquals(new ImportResult(List.of(), List.of("testId"), List.of(), List.of(), "b1: new work item 'testId' is being created"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(map), generateSettings(true)));
             verify(workItem, times(1)).setCustomField(eq("nullPossible"), eq(null));
         }
@@ -231,7 +231,7 @@ class ImportServiceTest {
                     "Expected IllegalArgumentException thrown, but it didn't");
             assertEquals("WorkItem id can only be imported if it is used as Link Column.", exception.getMessage());
 
-            assertEquals(new ImportResult(List.of(), List.of(), List.of(), List.of("a1"), "No work item found by ID 'a1'. Since the 'id' is used as the 'Link Column', new work item creation is impossible"),
+            assertEquals(new ImportResult(List.of(), List.of(), List.of(), List.of("a1"), "a1: no work item found by ID 'a1'. Since the 'id' is used as the 'Link Column', new work item creation is impossible"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(mapOne), generateSettingsForIdImport(true)));
 
             Map<String, Object> mapTwo = new HashMap<>(); // imported id cell is empty
@@ -250,7 +250,7 @@ class ImportServiceTest {
             mapThree.put("B", "newTitle");
 
             // test importing wi with id as link column and imported wi has same id as existing wi
-            assertEquals(new ImportResult(List.of(), List.of(), List.of("testId"), List.of(), "No changes were made to 'testId'"),
+            assertEquals(new ImportResult(List.of(), List.of(), List.of("testId"), List.of(), "testId: no changes were made to 'testId'"),
                     new ImportService(polarionServiceExt).processFile(project, List.of(mapThree), generateSettingsForIdImport(true)));
 
         }

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/PolarionServiceExtTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/PolarionServiceExtTest.java
@@ -1,0 +1,37 @@
+package ch.sbb.polarion.extension.excel_importer.service;
+
+import ch.sbb.polarion.extension.generic.test_extensions.CustomExtensionMock;
+import ch.sbb.polarion.extension.generic.test_extensions.PlatformContextMockExtension;
+import ch.sbb.polarion.extension.generic.util.PObjectListStub;
+import com.polarion.alm.tracker.ITrackerService;
+import com.polarion.alm.tracker.model.IWorkItem;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, PlatformContextMockExtension.class})
+class PolarionServiceExtTest {
+
+    @CustomExtensionMock
+    @SuppressWarnings("unused")
+    private ITrackerService trackerService;
+
+    @Test
+    void testFindWorkItemsById() {
+        IWorkItem testWorkItem = mock(IWorkItem.class);
+        when(trackerService.queryWorkItems(eq("project.id:testProjectId AND (fieldId:T-123 OR fieldId:T-456)"), anyString())).thenReturn(new PObjectListStub<>(List.of(testWorkItem)));
+        List<IWorkItem> workItems = new PolarionServiceExt().findWorkItemsById("testProjectId", "fieldId", List.of("T-123", "T-456"));
+        assertEquals(1, workItems.size());
+        assertSame(testWorkItem, workItems.get(0));
+    }
+
+}


### PR DESCRIPTION
Refs: #97

### Proposed changes

We have to ignore workitem type during data update. Type selected in the dropdown must be usod during workitem creation only.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
