### PR TITLE
refactor: register REST controllers as resource classes instead of provider singletons

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <groupId>ch.sbb.polarion.extensions</groupId>
         <artifactId>ch.sbb.polarion.extension.generic</artifactId>
-        <version>13.2.1</version>
+        <version>14.0.0</version>
     </parent>
 
     <artifactId>ch.sbb.polarion.extension.excel-importer</artifactId>

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/ExcelImporterRestApplication.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/ExcelImporterRestApplication.java
@@ -32,14 +32,14 @@ public class ExcelImporterRestApplication extends GenericRestApplication {
 
 
     @Override
-    protected @NotNull Set<Object> getExtensionControllerSingletons() {
+    protected @NotNull Set<Class<?>> getExtensionControllerClasses() {
         return Set.of(
-                new ExcelProcessingApiController(),
-                new ExcelProcessingInternalController(),
-                new ExcelToolInternalController(),
-                new ExcelToolApiController(),
-                new WorkItemsApiController(),
-                new WorkItemsInternalController()
+                ExcelProcessingApiController.class,
+                ExcelProcessingInternalController.class,
+                ExcelToolInternalController.class,
+                ExcelToolApiController.class,
+                WorkItemsApiController.class,
+                WorkItemsInternalController.class
         );
     }
 }

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelProcessingApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelProcessingApiController.java
@@ -3,10 +3,12 @@ package ch.sbb.polarion.extension.excel_importer.rest.controller;
 import ch.sbb.polarion.extension.excel_importer.service.ImportResult;
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Path;
 import javax.ws.rs.core.Response;
 import java.io.InputStream;
 
+@Singleton
 @Secured
 @Path("/api")
 public class ExcelProcessingApiController extends ExcelProcessingInternalController {

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelProcessingInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelProcessingInternalController.java
@@ -22,6 +22,7 @@ import org.apache.commons.io.IOUtils;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 import org.springframework.http.HttpStatus;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
@@ -40,6 +41,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
+@Singleton
 @Tag(name = "Excel Processing")
 @Hidden
 @Path("/internal")

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelToolApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelToolApiController.java
@@ -4,8 +4,10 @@ import ch.sbb.polarion.extension.excel_importer.rest.model.AttachTableParams;
 import ch.sbb.polarion.extension.excel_importer.service.ExportHtmlTableResult;
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Path;
 
+@Singleton
 @Secured
 @Path("/api/excel-tool")
 public class ExcelToolApiController extends ExcelToolInternalController {

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelToolInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/ExcelToolInternalController.java
@@ -17,6 +17,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.glassfish.jersey.media.multipart.FormDataParam;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Consumes;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
@@ -28,6 +29,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.Base64;
 import java.util.List;
 
+@Singleton
 @Hidden
 @Path("/internal/excel-tool")
 @Tag(name = "Excel Tool")

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/WorkItemsApiController.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/WorkItemsApiController.java
@@ -4,10 +4,12 @@ import ch.sbb.polarion.extension.generic.fields.model.FieldMetadata;
 import ch.sbb.polarion.extension.generic.rest.filter.Secured;
 import com.polarion.alm.tracker.model.ITypeOpt;
 
+import javax.inject.Singleton;
 import javax.ws.rs.Path;
 import java.util.List;
 import java.util.Set;
 
+@Singleton
 @Secured
 @Path("/api")
 public class WorkItemsApiController extends WorkItemsInternalController {

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/WorkItemsInternalController.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/rest/controller/WorkItemsInternalController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 
+import javax.inject.Singleton;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.PathParam;
@@ -18,6 +19,7 @@ import javax.ws.rs.core.MediaType;
 import java.util.List;
 import java.util.Set;
 
+@Singleton
 @Tag(name = "WorkItems")
 @Hidden
 @Path("/internal")


### PR DESCRIPTION
### Proposed changes

Move controller registration from getExtensionControllerSingletons() to getExtensionControllerClasses() and add @Singleton annotations to fix Jersey warning about controllers registered as providers.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
