### PR TITLE
fix: partially matching IDs resolve to wrong work item

### DIFF
--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
@@ -134,11 +134,12 @@ public class ImportService {
     static Predicate<IWorkItem> findWorkItemByFieldValue(String fieldId, Object value) {
         return workItem -> {
             Object workItemFieldValue = workItem.getValue(fieldId);
-            boolean equals = Objects.equals(workItemFieldValue, value);
-            if (!equals && workItemFieldValue != null && value != null) {
-                equals = workItemFieldValue.toString().contains(value.toString());
+            if (workItemFieldValue instanceof Text text) {
+                workItemFieldValue = text.getContent();
             }
-            return equals;
+            return Objects.equals(workItemFieldValue, value)
+                    || (workItemFieldValue != null && value != null && (!(workItemFieldValue instanceof String) || !(value instanceof String))
+                    && workItemFieldValue.toString().equals(value.toString()));
         };
     }
 

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
@@ -23,6 +23,7 @@ import com.polarion.alm.tracker.model.ILinkedWorkItemStruct;
 import com.polarion.alm.tracker.model.IHyperlinkStruct;
 import com.polarion.alm.tracker.model.IHyperlinkRoleOpt;
 import com.polarion.alm.tracker.model.IWorkItem;
+import com.polarion.core.util.types.Text;
 import com.polarion.platform.persistence.model.IStructure;
 import com.polarion.platform.IPlatformService;
 import com.polarion.platform.persistence.ICustomFieldsService;
@@ -1167,6 +1168,53 @@ class ImportServiceTest {
         assertFalse(predicate.test(workItem));
         when(workItem.getValue("someFieldId")).thenReturn(null);
         assertTrue(predicate.test(workItem));
+    }
+
+    @Test
+    void testFindWorkItemByFieldValueUnwrapsTextField() {
+        IWorkItem workItem = mock(IWorkItem.class);
+
+        Predicate<IWorkItem> predicate = ImportService.findWorkItemByFieldValue("someFieldId", "someValue");
+        when(workItem.getValue("someFieldId")).thenReturn(Text.plain("someValue"));
+        assertTrue(predicate.test(workItem));
+        when(workItem.getValue("someFieldId")).thenReturn(Text.plain("otherValue"));
+        assertFalse(predicate.test(workItem));
+        when(workItem.getValue("someFieldId")).thenReturn(Text.html("someValue"));
+        assertTrue(predicate.test(workItem));
+    }
+
+    @Test
+    void testFindWorkItemByFieldValueLooseCrossTypeCompare() {
+        IWorkItem workItem = mock(IWorkItem.class);
+
+        // non-String field vs String value: toString-based match
+        Predicate<IWorkItem> predicate = ImportService.findWorkItemByFieldValue("someFieldId", "5");
+        when(workItem.getValue("someFieldId")).thenReturn(5);
+        assertTrue(predicate.test(workItem));
+        when(workItem.getValue("someFieldId")).thenReturn(6);
+        assertFalse(predicate.test(workItem));
+
+        // String field vs non-String value: toString-based match
+        predicate = ImportService.findWorkItemByFieldValue("someFieldId", 5);
+        when(workItem.getValue("someFieldId")).thenReturn("5");
+        assertTrue(predicate.test(workItem));
+        when(workItem.getValue("someFieldId")).thenReturn("6");
+        assertFalse(predicate.test(workItem));
+
+        // both non-String: equal via Objects.equals
+        predicate = ImportService.findWorkItemByFieldValue("someFieldId", 5);
+        when(workItem.getValue("someFieldId")).thenReturn(5);
+        assertTrue(predicate.test(workItem));
+
+        // both non-String, different concrete types but same toString
+        predicate = ImportService.findWorkItemByFieldValue("someFieldId", 5L);
+        when(workItem.getValue("someFieldId")).thenReturn(5);
+        assertTrue(predicate.test(workItem));
+
+        // both non-String and toString differs
+        predicate = ImportService.findWorkItemByFieldValue("someFieldId", 5L);
+        when(workItem.getValue("someFieldId")).thenReturn(6);
+        assertFalse(predicate.test(workItem));
     }
 
     @Test


### PR DESCRIPTION
Refs: #199

### Proposed changes

We must lookup work items by ID value only on exact equality. An Excel row with ID `0001` matches the work item whose ID is exactly `0001` and never the one with ID `00011`.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [ ] I have updated any relevant documentation
