### PR TITLE
chore: align web.xml with canonical formatting

### DIFF
--- a/src/main/resources/webapp/excel-importer-admin/WEB-INF/web.xml
+++ b/src/main/resources/webapp/excel-importer-admin/WEB-INF/web.xml
@@ -1,63 +1,63 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-		 xmlns="https://jakarta.ee/xml/ns/jakartaee"
-		 xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
-		 version="6.1">
-	<display-name>excel-importer-admin</display-name>
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+         version="6.1">
+    <display-name>excel-importer-admin</display-name>
 
-	<filter>
-		<filter-name>DoAsFilter</filter-name>
-		<filter-class>com.polarion.portal.tomcat.servlets.DoAsFilter</filter-class>
-	</filter>
+    <filter>
+        <filter-name>DoAsFilter</filter-name>
+        <filter-class>com.polarion.portal.tomcat.servlets.DoAsFilter</filter-class>
+    </filter>
 
-	<filter-mapping>
-		<filter-name>DoAsFilter</filter-name>
-		<url-pattern>/*</url-pattern>
-	</filter-mapping>
+    <filter-mapping>
+        <filter-name>DoAsFilter</filter-name>
+        <url-pattern>/*</url-pattern>
+    </filter-mapping>
 
-	<servlet>
-		<servlet-name>excel-importer-admin-ui</servlet-name>
-		<servlet-class>ch.sbb.polarion.extension.excel_importer.ExcelImporterAdminUiServlet</servlet-class>
+    <servlet>
+        <servlet-name>excel-importer-admin-ui</servlet-name>
+        <servlet-class>ch.sbb.polarion.extension.excel_importer.ExcelImporterAdminUiServlet</servlet-class>
 
-		<init-param>
-			<param-name>debug</param-name>
-			<param-value>0</param-value>
-		</init-param>
-		<load-on-startup>1</load-on-startup>
-	</servlet>
+        <init-param>
+            <param-name>debug</param-name>
+            <param-value>0</param-value>
+        </init-param>
+        <load-on-startup>1</load-on-startup>
+    </servlet>
 
-	<servlet-mapping>
-		<servlet-name>excel-importer-admin-ui</servlet-name>
-		<url-pattern>/ui/*</url-pattern>
-	</servlet-mapping>
+    <servlet-mapping>
+        <servlet-name>excel-importer-admin-ui</servlet-name>
+        <url-pattern>/ui/*</url-pattern>
+    </servlet-mapping>
 
-	<session-config>
-		<session-timeout>30</session-timeout>
-	</session-config>
+    <session-config>
+        <session-timeout>30</session-timeout>
+    </session-config>
 
-	<mime-mapping>
-		<extension>log</extension>
-		<mime-type>text/plain</mime-type>
-	</mime-mapping>
+    <mime-mapping>
+        <extension>log</extension>
+        <mime-type>text/plain</mime-type>
+    </mime-mapping>
 
-	<security-constraint>
-		<web-resource-collection>
-			<web-resource-name>All</web-resource-name>
-			<url-pattern>/*</url-pattern>
-		</web-resource-collection>
-		<auth-constraint>
-			<role-name>user</role-name>
-		</auth-constraint>
-	</security-constraint>
+    <security-constraint>
+        <web-resource-collection>
+            <web-resource-name>All</web-resource-name>
+            <url-pattern>/*</url-pattern>
+        </web-resource-collection>
+        <auth-constraint>
+            <role-name>user</role-name>
+        </auth-constraint>
+    </security-constraint>
 
-	<!-- Login configuration uses form-based authentication -->
-	<login-config>
-		<auth-method>FORM</auth-method>
-		<realm-name>PolarionRealm</realm-name>
-		<form-login-config>
-			<form-login-page>/login/login</form-login-page>
-			<form-error-page>/login/error</form-error-page>
-		</form-login-config>
-	</login-config>
+    <!-- Login configuration uses form-based authentication -->
+    <login-config>
+        <auth-method>FORM</auth-method>
+        <realm-name>PolarionRealm</realm-name>
+        <form-login-config>
+            <form-login-page>/login/login</form-login-page>
+            <form-error-page>/login/error</form-error-page>
+        </form-login-config>
+    </login-config>
 </web-app>

--- a/src/main/resources/webapp/excel-importer/WEB-INF/web.xml
+++ b/src/main/resources/webapp/excel-importer/WEB-INF/web.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<web-app xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         xmlns="https://jakarta.ee/xml/ns/jakartaee"
+<web-app xmlns="https://jakarta.ee/xml/ns/jakartaee"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="https://jakarta.ee/xml/ns/jakartaee
-         https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
+                             https://jakarta.ee/xml/ns/jakartaee/web-app_6_1.xsd"
          version="6.1">
     <display-name>excel-importer</display-name>
 


### PR DESCRIPTION
Standardizes every `web.xml` descriptor on the canonical `aad-synchronizer`
formatting so all extensions share an identical header and indentation style.

### Changes
- `web-app` header attribute order: `xmlns` before `xmlns:xsi`, with the
  `schemaLocation` continuation aligned under the namespace URI (the Siemens
  2606 canonical header)
- 4-space indentation, no tabs
- no blank line between the header and the first body element

Formatting only -- no functional change. The Jakarta schema
(`web-app_6_1.xsd`, `version="6.1"`) is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
