### PR TITLE
feat: replace the native confirm with a dialog

### DIFF
--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "excel-importer-app",
       "version": "1.0.0",
       "dependencies": {
-        "@grigoriev/react-sbb-polarion": "^0.0.9",
+        "@grigoriev/react-sbb-polarion": "^0.0.10",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sonner": "^2.0.7"
@@ -506,9 +506,9 @@
       }
     },
     "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.0.9",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.0.9.tgz",
-      "integrity": "sha512-ZgRCDEIwpwLp2FNacBchyROQv69RJErVZipbq7PocYhOK+WMU0k0swMm/mMKer6A3N66/h0PeR2zcnsZj4p9Zw==",
+      "version": "0.0.10",
+      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.0.10.tgz",
+      "integrity": "sha512-9PLhDeB8l6Z/6ElNQL01cwnUbd6DPyduJA6BsJ2bi5cqGe2nhZUrIATEL9XQg6w0tg0frxpxq7IwhjOKo8ku3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.9.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.0.9",
+    "@grigoriev/react-sbb-polarion": "^0.0.10",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7"

--- a/ui/src/pages/Mappings.tsx
+++ b/ui/src/pages/Mappings.tsx
@@ -6,6 +6,7 @@ import {
   PageLayout,
   RevisionsTable,
   SearchableSelect,
+  useConfirm,
 } from '@grigoriev/react-sbb-polarion';
 import { toast } from 'sonner';
 import MappingRow from '../components/MappingRow';
@@ -35,6 +36,7 @@ function isTestStepsField(field: FieldMetadata | null): boolean {
 export default function Mappings() {
   const settings = useSettings();
   const scope = getScope();
+  const { confirm, confirmDialog } = useConfirm();
   const projectId = getProjectIdFromScope(scope);
   const paneRef = useRef<ConfigurationsPaneHandle>(null);
 
@@ -317,7 +319,7 @@ export default function Mappings() {
 
   const handleCancel = async () => {
     if (!selectedConfig) return;
-    if (!window.confirm('Cancel editing and revert to the last persisted state?')) return;
+    if (!(await confirm('Cancel editing and revert to the last persisted state?'))) return;
     try {
       const model = await settings.loadContent(selectedConfig, scope);
       applySettings(model);
@@ -603,6 +605,8 @@ export default function Mappings() {
         onAccept={acceptOptions}
         onCancel={() => setOptionsFieldId(null)}
       />
+
+      {confirmDialog}
     </PageLayout>
   );
 }

--- a/ui/test/Mappings.test.tsx
+++ b/ui/test/Mappings.test.tsx
@@ -65,6 +65,16 @@ afterEach(() => {
   window.top?.document.querySelectorAll('script[id$="-breadcrumb-bridge"]').forEach((s) => s.remove());
 });
 
+/** Answer the confirmation dialog the page renders in place of the former window.confirm. */
+async function answerDialog(label: 'OK' | 'Cancel') {
+  await vi.waitFor(() => expect(document.querySelector('.rsp-modal')).not.toBeNull());
+  const button = Array.from(document.querySelectorAll<HTMLButtonElement>('.rsp-modal-footer .sbb-btn')).find(
+    (b) => (b.textContent ?? '').trim() === label,
+  );
+  if (!button) throw new Error(`dialog button "${label}" not found`);
+  button.click();
+}
+
 describe('Mappings page', () => {
   it('loads the selected configuration, its content, and the work-item fields', async () => {
     await mountLoaded();
@@ -146,8 +156,8 @@ describe('Mappings page', () => {
       { method: 'GET', match: /\/projects\/[^/]+\/workitem_types\/[^/]+\/fields/, json: FIELDS },
       { method: 'GET', match: /\/projects\/[^/]+\/workitem_types(\?|$)/, json: WORKITEM_TYPES },
     ]);
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     sbbButton('Cancel').click();
+    await answerDialog('OK');
     await vi.waitFor(() => expect(document.body.textContent).toContain('Error occurred loading the data'));
   });
 
@@ -182,10 +192,10 @@ describe('Mappings page', () => {
 
   it('reloads the persisted content when Cancel is confirmed', async () => {
     await mountLoaded();
-    vi.spyOn(window, 'confirm').mockReturnValue(true);
     const contentCalls = () => fetchMock.mock.calls.filter((c) => /\/content/.test(String(c[0]))).length;
     const before = contentCalls();
     sbbButton('Cancel').click();
+    await answerDialog('OK');
     await vi.waitFor(() => expect(contentCalls()).toBeGreaterThan(before));
   });
 


### PR DESCRIPTION
### Proposed changes

The admin UI still asked for confirmation through the browser's `window.confirm`. That renders an
OS-level dialog that ignores the SBB styling entirely and, in a form extension, escapes the shadow
root the panel lives in — the one native-looking element left in an otherwise fully React page.

react-sbb-polarion 0.0.10 ships `useConfirm`, a promise-based confirmation built on the shared
`Modal`. This PR bumps RSP to that release and switches every confirmation over to it, so the prompt
now looks like the rest of the page.

The bump has to be explicit: a caret range on a `0.x.y` version pins the patch, so `^0.0.9` never
resolves to 0.0.10.

The tests that used to stub `window.confirm` now click the real dialog, which also makes them cover
the wiring rather than the stub.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
