### PR TITLE
fix: importing field to description changes text to plain

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -22,6 +22,7 @@ repos:
       - id: no-commit-to-branch
       - id: mixed-line-ending
       - id: end-of-file-fixer
+        exclude: \.xlsx$  # Spreadsheet fixtures. src/test/resources/bad.xlsx holds plain text on purpose, so this hook reads it as text and appends a newline
       - id: pretty-format-json
         alias: pretty-format-openapi-json
         args: [--autofix, --no-ensure-ascii, '--top-keys=openapi,info,servers,paths,components']
@@ -50,7 +51,8 @@ repos:
       # React app (ui/) - mirrors react-sbb-polarion's hooks. `npm --prefix ui run` executes with ui/
       # as the working directory, so Prettier's globs and `eslint .` stay scoped to the app. Check-only
       # (they block the commit but do not modify the tree); run `npm --prefix ui run format`/`lint:fix`
-      # to fix. Gated on ui/ source files so non-ui commits skip them.
+      # to fix. Gated on ui/ source files so non-ui commits skip them. The Vitest suite is deliberately
+      # not a hook: it needs Docker and takes too long for a commit. The Maven test phase and CI run it.
       - id: ui-prettier
         name: UI Prettier (format:check)
         entry: npm --prefix ui run format:check
@@ -63,14 +65,6 @@ repos:
         language: system
         pass_filenames: false
         files: ^ui/.*\.(ts|tsx|js|mjs)$
-      # Dockerized Vitest (behavior + visual regression) with the 80% coverage gate. Heavy (~30-60s+,
-      # needs Docker running); gated on ui/ source changes.
-      - id: ui-test-coverage-docker
-        name: UI Vitest + coverage gate (Docker)
-        entry: npm --prefix ui run test:coverage:docker
-        language: system
-        pass_filenames: false
-        files: ^ui/.*\.(ts|tsx|css)$
   - repo: https://github.com/zricethezav/gitleaks
     rev: v8.30.1
     hooks:

--- a/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
+++ b/src/main/java/ch/sbb/polarion/extension/excel_importer/service/ImportService.java
@@ -219,17 +219,21 @@ public class ImportService {
         // The linkColumn field's value can't change, therefore it doesn't need to be overwritten.
         // However, it must be saved to the newly created work item otherwise sequential imports will produce several objects.
         String fieldId = fieldMetadata.getId();
+        // The value is prepared upfront because the value which gets written must also be the one compared with the
+        // existing value. Otherwise text fields always look different - a String never equals the stored Text - and
+        // every import rewrites them, incrementing the work item revision.
+        Object preparedValue = prepareValue(value, fieldMetadata);
         if (!IUniqueObject.KEY_ID.equals(fieldId) && (!linkColumnId.equals(fieldId) || !workItem.isPersisted()) &&
                 (context.settings.isOverwriteWithEmpty() || !isEmpty(value)) &&
                 ensureValidValue(value, fieldMetadata) &&
-                existingValueDiffers(workItem, fieldId, value, fieldMetadata, context.settings.isUnlinkExisting())) {
+                existingValueDiffers(workItem, fieldId, preparedValue, fieldMetadata, context.settings.isUnlinkExisting())) {
             if (IWorkItem.KEY_LINKED_WORK_ITEMS.equals(fieldId)) {
                 setLinkedWorkItems(workItem, value, context);
             } else if (IWorkItem.KEY_HYPERLINKS.equals(fieldId)) {
                 workItem.getHyperlinks().clear();
-                addHyperlinks(workItem, prepareValue(value, fieldMetadata));
+                addHyperlinks(workItem, preparedValue);
             } else {
-                polarionServiceExt.setFieldValue(workItem, fieldId, prepareValue(value, fieldMetadata), context.settings.getEnumsMapping());
+                polarionServiceExt.setFieldValue(workItem, fieldId, preparedValue, context.settings.getEnumsMapping());
             }
         } else if (IUniqueObject.KEY_ID.equals(fieldId) && !linkColumnId.equals(fieldId)) {
             // If the work item id is imported, it must be the Link Column. Its value also can't be set by imported data unlike other possible Link Column fields.
@@ -313,8 +317,11 @@ public class ImportService {
 
     @VisibleForTesting
     Object prepareValue(Object value, @NotNull FieldMetadata fieldMetadata) {
-        if (FieldType.RICH.getType().equals(fieldMetadata.getType()) && value instanceof String richTextString) {
-            return HTMLHelper.convertPlainToHTML(richTextString);
+        if (value instanceof String stringValue && fieldMetadata.isTextType()) {
+            // Text fields are set as Text instances rather than as strings: this is what Polarion stores, it fixes the
+            // text type of the stored value, and it lets existingValueDiffers() compare like with like.
+            // Imported cells always hold plain text, hence rich text fields require conversion of their content to HTML.
+            return fieldMetadata.isRichText() ? Text.html(HTMLHelper.convertPlainToHTML(stringValue)) : Text.plain(stringValue);
         }
         return value;
     }

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
@@ -502,6 +502,47 @@ class ImportServiceTest {
     }
 
     @Test
+    @SuppressWarnings({"rawtypes", "unchecked"})
+    void testFillWorkItemFieldsWithHyperlinks() {
+        PolarionServiceExt polarionService = mock(PolarionServiceExt.class);
+        ImportService service = new ImportService(polarionService);
+
+        FieldMetadata hyperlinksField = FieldMetadata.builder().id("hyperlinks").type(FieldType.LIST.getType()).build();
+        when(polarionService.getWorkItemsFields("projectId", "requirement")).thenReturn(Set.of(hyperlinksField));
+
+        IWorkItem workItem = mock(IWorkItem.class, RETURNS_DEEP_STUBS);
+        when(workItem.getProjectId()).thenReturn("projectId");
+        ITypeOpt typeOpt = mock(ITypeOpt.class);
+        when(typeOpt.getId()).thenReturn("requirement");
+        when(workItem.getType()).thenReturn(typeOpt);
+
+        // an outdated hyperlink is present, it must be dropped before the imported one is added
+        IHyperlinkStruct outdatedHyperlink = mock(IHyperlinkStruct.class);
+        when(outdatedHyperlink.getUri()).thenReturn("https://outdated.com");
+        java.util.Collection existingHyperlinks = new ArrayList<>(List.of(outdatedHyperlink));
+        when(workItem.getHyperlinks()).thenReturn(existingHyperlinks);
+
+        IHyperlinkRoleOpt roleEnum = mock(IHyperlinkRoleOpt.class);
+        when(workItem.getProject().getHyperlinkRoleEnum().wrapOption("ref_ext")).thenReturn(roleEnum);
+
+        ExcelSheetMappingSettingsModel model = ExcelSheetMappingSettingsModel.builder()
+                .columnsMapping(Map.of("A", "hyperlinks"))
+                .stepsMapping(Map.of())
+                .overwriteWithEmpty(true)
+                .build();
+
+        Map<String, Object> mappingRecord = new HashMap<>();
+        mappingRecord.put("A", "My Link;ref_ext;https://example.com");
+
+        service.fillWorkItemFields(workItem, mappingRecord, contextFor(model), "linkField");
+
+        // hyperlinks go through addHyperlinks, not setFieldValue
+        verify(polarionService, never()).setFieldValue(any(IWorkItem.class), anyString(), any(), any());
+        verify(workItem).addHyperlink("https://example.com", roleEnum, "My Link");
+        assertTrue(existingHyperlinks.isEmpty());
+    }
+
+    @Test
     void testFillWorkItemFieldsNullTypeAndTestStepsPrefix() {
         PolarionServiceExt polarionService = mock(PolarionServiceExt.class);
         ImportService service = new ImportService(polarionService);

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
@@ -336,10 +336,22 @@ class ImportServiceTest {
         assertEquals("aaa\nbbb", service.prepareValue("aaa\nbbb", stringMetadata));
 
         // in case of rich text some characters must be converted to their HTML equivalents
-        FieldMetadata richMetadata = FieldMetadata.builder().id("fieldId").type(FieldType.RICH.getType()).build();
-        assertEquals("aaa<br/>bbb", service.prepareValue("aaa\nbbb", richMetadata));
-        assertEquals("aaa&nbsp;&nbsp;&nbsp;&nbsp;bbb", service.prepareValue("aaa\tbbb", richMetadata));
-        assertEquals("&lt;tag&gt;&amp;", service.prepareValue("<tag>&", richMetadata));
+        FieldMetadata richMetadata = FieldMetadata.builder().id("fieldId").type(FieldType.RICH.getType()).custom(true).build();
+        assertEquals(Text.html("aaa<br/>bbb"), service.prepareValue("aaa\nbbb", richMetadata));
+        assertEquals(Text.html("aaa&nbsp;&nbsp;&nbsp;&nbsp;bbb"), service.prepareValue("aaa\tbbb", richMetadata));
+        assertEquals(Text.html("&lt;tag&gt;&amp;"), service.prepareValue("<tag>&", richMetadata));
+
+        // a built-in Text field like 'description' declares no 'html' subtype, but Polarion still treats it as rich text
+        FieldMetadata descriptionMetadata = FieldMetadata.builder().id("description").type(FieldType.TEXT.getType()).custom(false).build();
+        assertEquals(Text.html("aaa<br/>bbb"), service.prepareValue("aaa\nbbb", descriptionMetadata));
+
+        // a custom Text field without the 'html' subtype stays plain text
+        FieldMetadata customTextMetadata = FieldMetadata.builder().id("fieldId").type(FieldType.TEXT.getType()).custom(true).build();
+        assertEquals(Text.plain("aaa\nbbb"), service.prepareValue("aaa\nbbb", customTextMetadata));
+
+        // non-string values are left to the converters of the generic extension
+        assertEquals(42d, service.prepareValue(42d, descriptionMetadata));
+        assertNull(service.prepareValue(null, descriptionMetadata));
     }
 
     @Test
@@ -409,6 +421,44 @@ class ImportServiceTest {
         verify(polarionService).setFieldValue(eq(workItem), eq("priority"), eq("high"), any());
         // column C has no mapping and no prefix → skipped, so exactly 2 calls total
         verify(polarionService, times(2)).setFieldValue(any(IWorkItem.class), anyString(), any(), any());
+    }
+
+    @Test
+    void testFillWorkItemFieldsWritesDescriptionAsHtml() {
+        PolarionServiceExt polarionService = mock(PolarionServiceExt.class);
+        ImportService service = new ImportService(polarionService);
+
+        // 'description' is a built-in Text field: its type carries no 'html' subtype, yet Polarion stores it as HTML
+        FieldMetadata descriptionField = FieldMetadata.builder().id("description").type(FieldType.TEXT.getType()).custom(false).build();
+        when(polarionService.getWorkItemsFields("projectId", "requirement")).thenReturn(Set.of(descriptionField));
+
+        IWorkItem workItem = mock(IWorkItem.class);
+        when(workItem.getProjectId()).thenReturn("projectId");
+        ITypeOpt typeOpt = mock(ITypeOpt.class);
+        when(typeOpt.getId()).thenReturn("requirement");
+        when(workItem.getType()).thenReturn(typeOpt);
+
+        ExcelSheetMappingSettingsModel model = ExcelSheetMappingSettingsModel.builder()
+                .columnsMapping(Map.of("A", "description"))
+                .stepsMapping(Map.of())
+                .overwriteWithEmpty(true)
+                .build();
+
+        Map<String, Object> mappingRecord = new HashMap<>();
+        mappingRecord.put("A", "line1\nline2");
+
+        service.fillWorkItemFields(workItem, mappingRecord, contextFor(model), "linkField");
+
+        verify(polarionService).setFieldValue(eq(workItem), eq("description"), eq(Text.html("line1<br/>line2")), any());
+
+        // the same value again must not be written a second time, it would only increment the work item revision
+        clearInvocations(polarionService);
+        when(polarionService.getWorkItemsFields("projectId", "requirement")).thenReturn(Set.of(descriptionField));
+        when(polarionService.getFieldValue(workItem, "description")).thenReturn(Text.html("line1<br/>line2"));
+
+        service.fillWorkItemFields(workItem, mappingRecord, contextFor(model), "linkField");
+
+        verify(polarionService, never()).setFieldValue(any(IWorkItem.class), anyString(), any(), any());
     }
 
     @Test
@@ -1013,6 +1063,12 @@ class ImportServiceTest {
         assertTrue(service.existingValueDiffers(workItem, "fieldId", "42", floatMetadata, false));
         assertTrue(service.existingValueDiffers(workItem, "fieldId", null, floatMetadata, false));
 
+        // text fields are compared as Text instances, otherwise an unchanged value would be rewritten on every import
+        FieldMetadata descriptionMetadata = FieldMetadata.builder().id("description").type(FieldType.TEXT.getType()).build();
+        when(polarionService.getFieldValue(workItem, "description")).thenReturn(Text.html("aaa<br/>bbb"));
+        assertFalse(service.existingValueDiffers(workItem, "description", Text.html("aaa<br/>bbb"), descriptionMetadata, false));
+        assertTrue(service.existingValueDiffers(workItem, "description", Text.html("aaa<br/>ccc"), descriptionMetadata, false));
+        assertTrue(service.existingValueDiffers(workItem, "description", Text.plain("aaa<br/>bbb"), descriptionMetadata, false));
     }
 
     @Test

--- a/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
+++ b/src/test/java/ch/sbb/polarion/extension/excel_importer/service/ImportServiceTest.java
@@ -502,7 +502,7 @@ class ImportServiceTest {
     }
 
     @Test
-    @SuppressWarnings({"rawtypes", "unchecked"})
+    @SuppressWarnings("rawtypes")
     void testFillWorkItemFieldsWithHyperlinks() {
         PolarionServiceExt polarionService = mock(PolarionServiceExt.class);
         ImportService service = new ImportService(polarionService);

--- a/ui/README.md
+++ b/ui/README.md
@@ -43,9 +43,10 @@ npm run lint            # ESLint: report problems
 npm run lint:fix        # ESLint: auto-fix what it can
 ```
 
-The repo's pre-commit hooks run `format:check` + `lint` (and the Dockerized Vitest suite) on any
-change under `ui/`. They are **check-only** and never modify your files - fix locally with
-`npm run format` / `npm run lint:fix` before committing.
+The repo's pre-commit hooks run `format:check` + `lint` on any change under `ui/`. They are
+**check-only** and never modify your files - fix locally with `npm run format` / `npm run lint:fix`
+before committing. The Vitest suite is not a hook: it needs Docker and takes too long for a commit,
+so run it yourself (see [Testing](#testing)) before you push.
 
 ## Testing
 
@@ -69,7 +70,7 @@ the visual snapshots match their references. **Docker must be running.**
 ```bash
 cd ui
 npm run test:docker            # full suite (behavior + visual) in the pinned image
-npm run test:coverage:docker   # full suite + the 80% coverage gate (what pre-commit runs)
+npm run test:coverage:docker   # full suite + the 80% coverage gate (what the Maven build runs)
 npm run test:update:docker     # regenerate the committed visual reference PNGs (do this in Docker only)
 ```
 
@@ -106,7 +107,8 @@ as a blank page in Polarion and no test catches it.
 
 **One command, locally and in CI: `npm run test:coverage:docker`.** It runs the full suite (behavior +
 visual regression) plus the 80% istanbul coverage gate inside the pinned Playwright Docker image, which
-is what the Maven `test` phase and the pre-commit hook execute. Docker must be running.
+is what the Maven `test` phase executes. Docker must be running. No pre-commit hook runs the tests, so
+run this yourself before you push.
 
 ```bash
 npm run test:coverage:docker   # the canonical run: full suite + coverage gate, in the pinned image

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -17,6 +17,7 @@
         "@eslint/js": "10.0.1",
         "@testing-library/jest-dom": "7.0.0",
         "@trivago/prettier-plugin-sort-imports": "6.0.2",
+        "@types/node": "24.13.3",
         "@types/react": "19.2.18",
         "@types/react-dom": "19.2.4",
         "@vitejs/plugin-react": "6.0.5",
@@ -1010,6 +1011,16 @@
       "integrity": "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "24.13.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
+      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
     },
     "node_modules/@types/prismjs": {
       "version": "1.26.6",
@@ -3585,6 +3596,13 @@
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/update-browserslist-db": {
       "version": "1.3.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -30,6 +30,7 @@
     "@eslint/js": "10.0.1",
     "@testing-library/jest-dom": "7.0.0",
     "@trivago/prettier-plugin-sort-imports": "6.0.2",
+    "@types/node": "24.13.3",
     "@types/react": "19.2.18",
     "@types/react-dom": "19.2.4",
     "@vitejs/plugin-react": "6.0.5",

--- a/ui/scripts/docker-test.mjs
+++ b/ui/scripts/docker-test.mjs
@@ -30,6 +30,10 @@ const args = [
   // anywhere else they skip instead of failing on the host's font metrics.
   '-e',
   'PIXEL_REFERENCES=1',
+  // Keeps corepack from announcing the npm download on stderr, which the Maven frontend plugin would
+  // then print as an [ERROR] line in an otherwise clean build.
+  '-e',
+  'COREPACK_ENABLE_DOWNLOAD_PROMPT=0',
   '-v',
   `${uiDir}:/work`,
   // Shadow node_modules so the container's Linux install does not overwrite host binaries.
@@ -40,7 +44,12 @@ const args = [
   image,
   'bash',
   '-c',
-  `npm ci && npm run ${script}`,
+  // The image's bundled npm is older than this project's `packageManager` pin, so `npm ci` used to warn
+  // EBADENGINE on every run. corepack installs the pinned npm instead, which both silences the warning
+  // and makes the container resolve the lock file with the very npm the developers use - about 4s.
+  // Tolerated rather than required: a future image without corepack falls back to the bundled npm, and
+  // says so, instead of failing the whole suite over the toolchain.
+  `corepack enable npm || echo "corepack unavailable - using the image's bundled npm"; npm ci && npm run ${script}`,
 ];
 
 console.log(`> docker ${args.join(' ')}`);

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -43,6 +43,11 @@ export default defineConfig({
   test: {
     include: ['test/**/*.{test,spec}.{ts,tsx}'],
     setupFiles: ['./test/setup.ts'],
+    // Insulate the suite from a developer's `ui/.env.local`. Vite loads that file in test mode too, so a
+    // personal VITE_BEARER_TOKEN would otherwise switch useRemote to the /api base and add an
+    // Authorization header, which is not the session-auth default the tests are written against. Empty,
+    // not removed, so `vi.stubEnv('VITE_BEARER_TOKEN', ...)` still works where a test wants a token.
+    env: { VITE_BEARER_TOKEN: '' },
     // Run test files one at a time. Under high parallelism the Playwright browser provider
     // intermittently fails a worker with "Vitest failed to find the runner"; serializing the files
     // avoids that race. The suite is small and each file is fast, so the cost is minor.
@@ -65,22 +70,24 @@ export default defineConfig({
     },
     coverage: {
       // istanbul (source instrumented at transform time), NOT v8: in browser mode v8 intermittently
-      // reports 0% depending on the dep-optimization cache. `all: false` so the istanbul uncovered-files
-      // pass (which can crash in browser mode) never runs.
+      // reports 0% depending on the dep-optimization cache.
       provider: 'istanbul',
       reporter: ['text', 'html', 'lcov'],
       reportsDirectory: './coverage',
-      all: false,
+      // `include` also pulls untested files into the report (Vitest 4 runs the uncovered-files pass
+      // whenever it is set), so an unimported source file cannot silently pass the threshold gate. It
+      // replaced `coverage.all`, which Vitest 4 dropped from the option type: the `all: false` that used
+      // to sit here did nothing at runtime - the istanbul provider never reads it - and only showed up as
+      // a type error in the IDE.
       include: ['src/**'],
       // Excluded: declaration files, CSS, the bootstrap entry (main.tsx), and the dev-only Landing page
       // (vite-dev scaffolding never opened in Polarion; the router test covers its selection logic).
       // Do NOT exclude real product code to hit the gate - and do not exclude `types.ts`: it holds only
       // interfaces, which erase at transpile, so listing it hides nothing and blurs this list.
       exclude: ['src/**/*.d.ts', 'src/**/*.css', 'src/main.tsx', 'src/pages/Landing.tsx'],
-      // Uniform 80% gate (currently ~94 stmts / ~92 funcs / ~97 lines / ~80 branches). ColumnInput now
+      // Uniform 80% gate (currently ~96 stmts / ~94 funcs / ~99 lines / ~90 branches). ColumnInput now
       // builds its editable combobox from react-sbb-polarion's bundled createEditableSelect (no runtime
-      // fetch), so it is exercised in tests too; the branches left uncovered are defensive ref guards
-      // and useRemote's token-auth path (needs VITE_BEARER_TOKEN).
+      // fetch), so it is exercised in tests too; the branches left uncovered are defensive ref guards.
       thresholds: {
         statements: 80,
         functions: 80,


### PR DESCRIPTION
EBADENGINE & VITE_BEARER_TOKEN fix, from pre-commit coverage tests removal

Refs: #285

### Proposed changes

We have to fix the bug when the description field changes its type from html to plain after import.

### Checklist

Before creating a PR, run through this checklist and mark each as complete:
- [x] I have read the [`CONTRIBUTING`](CONTRIBUTING.md) document
- [x] If applicable, I have added tests that prove my fix is effective or that my feature works
- [x] If applicable, I have checked that any relevant tests pass after adding my changes
- [x] I have updated any relevant documentation
