### PR TITLE
feat: RSP usage for breadcrumbs/toolbar controls

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.2.0",
+    "@grigoriev/react-sbb-polarion": "^0.3.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7"

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,14 +1,8 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { configureGenericModules } from '@grigoriev/react-sbb-polarion';
 import '@grigoriev/react-sbb-polarion/style.css';
 import App from './App';
 import './App.css';
-
-// The shared UI wrappers (SearchableSelect) load the generic ES modules from this extension's own
-// Polarion webapp context at runtime. The dev proxy forwards this absolute path to Polarion, and in
-// Polarion it is same-origin.
-configureGenericModules('/polarion/excel-importer-app/ui/generic/js/modules/');
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -1,5 +1,23 @@
-import { defineConfig, loadEnv } from 'vite';
 import react from '@vitejs/plugin-react';
+import { copyFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { defineConfig, loadEnv } from 'vite';
+
+// react-sbb-polarion ships BreadcrumbBridge.js as a classic script that runs in the Polarion shell
+// window, outside this app's frame, so it cannot be imported and has to be served as a file. Copying
+// it next to the built app is what replaces fetching it from generic's webapp.
+function copyRspShellScripts() {
+  return {
+    name: 'copy-rsp-shell-scripts',
+    writeBundle(options) {
+      const require = createRequire(import.meta.url);
+      copyFileSync(
+        require.resolve('@grigoriev/react-sbb-polarion/breadcrumb-bridge.js'),
+        `${options.dir}/breadcrumb-bridge.js`,
+      );
+    },
+  };
+}
 
 export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
@@ -48,7 +66,7 @@ export default defineConfig(({ command, mode }) => {
   }
 
   return {
-    plugins: [react()],
+    plugins: [react(), copyRspShellScripts()],
     resolve,
     // Never let a developer's personal access token reach a shipped bundle. VITE_BEARER_TOKEN is a
     // `vite dev` convenience (it switches useRemote to the token-authenticated /api endpoints); Vite


### PR DESCRIPTION
Moves the app-header breadcrumb onto **react-sbb-polarion**, so nothing is fetched from the generic webapp for it any more.

`BreadcrumbInjector` now loads the bridge from this extension's own app bundle, where the Vite build copies it, and `configureGenericModules` is gone with it.


## Depends on an unreleased RSP

Requires **react-sbb-polarion 0.3.0**, which is not published yet (SchweizerischeBundesbahnen/react-sbb-polarion#64). Until it lands, `npm ci` fails with `ETARGET` here and in CI, so this PR is a **draft**. On the first commit after the release the lockfile regenerates and everything goes green.

Verified locally against the real RSP build, and deployed to a live Polarion together with generic and the other migrated extensions.

Refs SchweizerischeBundesbahnen/react-sbb-polarion#59
