### PR TITLE
build: switch to @sbb-polarion/react-sbb-polarion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 
 ### Bug Fixes
 
-* **deps:** update dependency @grigoriev/react-sbb-polarion to ^0.2.0 ([#275](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/issues/275)) ([12aca2b](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/commit/12aca2b47ea07e4747ebd380abd7b2df9eea96d3))
+* **deps:** update dependency @sbb-polarion/react-sbb-polarion to ^0.2.0 ([#275](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/issues/275)) ([12aca2b](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/commit/12aca2b47ea07e4747ebd380abd7b2df9eea96d3))
 * **deps:** update dependency ch.sbb.polarion.extensions:ch.sbb.polarion.extension.generic to v15.10.0 ([#265](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/issues/265)) ([0c3bf8f](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/commit/0c3bf8ff0ebe6ad5d747846d89ab11cfe92db8b1))
 * **deps:** update dependency ch.sbb.polarion.extensions:ch.sbb.polarion.extension.generic to v15.10.1 ([#272](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/issues/272)) ([94d79e9](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/commit/94d79e94fc44c0853c4fb33dc4bcde961fe75b47))
 * **deps:** update dependency ch.sbb.polarion.extensions:ch.sbb.polarion.extension.generic to v15.11.0 ([#287](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/issues/287)) ([0643626](https://github.com/SchweizerischeBundesbahnen/ch.sbb.polarion.extension.excel-importer/commit/0643626227fdfac4f2cf5959630b5ed22813dc1a))

--- a/ui/README.md
+++ b/ui/README.md
@@ -1,6 +1,6 @@
 # Excel Importer UI
 
-A React + Vite single-page app on [react-sbb-polarion](https://github.com/grigoriev/react-sbb-polarion)
+A React + Vite single-page app on [react-sbb-polarion](https://github.com/SchweizerischeBundesbahnen/react-sbb-polarion)
 (RSP). It replaces the legacy JSP admin pages (`about`, `mappings`, `user-guide`, `import-file`), which
 have been removed together with the whole `excel-importer-admin/` webapp - the admin-menu icons and the
 build-generated help HTML are served from this app's own context now.

--- a/ui/index.html
+++ b/ui/index.html
@@ -7,7 +7,7 @@
     <!-- Baseline Polarion look. Served by Polarion in production; 404s harmlessly during `vite dev`. -->
     <link rel="stylesheet" href="/polarion/wiki/skins/sidecar/presentation.css" />
     <!-- Control design tokens + searchable-dropdown / checkboxes / buttons / alerts CSS now ship
-         bundled in @grigoriev/react-sbb-polarion (imported in main.tsx), no longer
+         bundled in @sbb-polarion/react-sbb-polarion (imported in main.tsx), no longer
          linked from generic. -->
     <!-- Markdown styling for the About page README help article (served by GenericUiServlet). -->
     <link rel="stylesheet" href="/polarion/excel-importer-app/ui/generic/css/github-markdown-light.css" />

--- a/ui/package-lock.json
+++ b/ui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "excel-importer-app",
       "version": "1.0.0",
       "dependencies": {
-        "@grigoriev/react-sbb-polarion": "^0.2.0",
+        "@sbb-polarion/react-sbb-polarion": "^1.0.0",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
         "sonner": "^2.0.7"
@@ -433,24 +433,6 @@
         "node": "^20.19.0 || ^22.13.0 || >=24"
       }
     },
-    "node_modules/@grigoriev/react-sbb-polarion": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@grigoriev/react-sbb-polarion/-/react-sbb-polarion-0.2.0.tgz",
-      "integrity": "sha512-Yiuy22TWG5qWVJLYQx/b0FrMip/FJmfiGp6vUPcXN2JYILTmvuXTPK7vBTWbVOc8cobtnyPRtIx7h+IFn0JzmQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "refractor": "^5.0.0"
-      },
-      "engines": {
-        "node": ">=24.0.0",
-        "npm": ">=11"
-      },
-      "peerDependencies": {
-        "react": "^19.0.0",
-        "react-dom": "^19.0.0",
-        "sonner": "^2.0.7"
-      }
-    },
     "node_modules/@humanfs/core": {
       "version": "0.19.2",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
@@ -856,6 +838,24 @@
       "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@sbb-polarion/react-sbb-polarion": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@sbb-polarion/react-sbb-polarion/-/react-sbb-polarion-1.0.0.tgz",
+      "integrity": "sha512-hTk4oewJvkUL02blEktAJXMc4IiyftaG6fH4+viNP5wdH12mJxKMfHZAmB4xA50vnvFrfdZDhLrxPP/+fC6VwA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "refractor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=24.0.0",
+        "npm": ">=11"
+      },
+      "peerDependencies": {
+        "react": "^19.0.0",
+        "react-dom": "^19.0.0",
+        "sonner": "^2.0.7"
+      }
     },
     "node_modules/@standard-schema/spec": {
       "version": "1.1.0",

--- a/ui/package.json
+++ b/ui/package.json
@@ -21,7 +21,7 @@
     "lint:fix": "eslint . --fix"
   },
   "dependencies": {
-    "@grigoriev/react-sbb-polarion": "^0.2.0",
+    "@sbb-polarion/react-sbb-polarion": "^1.0.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "sonner": "^2.0.7"

--- a/ui/src/App.css
+++ b/ui/src/App.css
@@ -303,7 +303,7 @@ code {
   line-height: 1.5;
 }
 
-/* --- Options mapping modal content (the modal shell itself lives in @grigoriev/react-sbb-polarion) --- */
+/* --- Options mapping modal content (the modal shell itself lives in @sbb-polarion/react-sbb-polarion) --- */
 .option-mapping-hint-wrapper {
   display: flex;
   justify-content: center;

--- a/ui/src/App.tsx
+++ b/ui/src/App.tsx
@@ -1,4 +1,4 @@
-import { BreadcrumbInjector, Toaster } from '@grigoriev/react-sbb-polarion';
+import { BreadcrumbInjector, Toaster } from '@sbb-polarion/react-sbb-polarion';
 import { findFeature } from './features';
 import Landing from './pages/Landing';
 

--- a/ui/src/components/ColumnInput.tsx
+++ b/ui/src/components/ColumnInput.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useRef } from 'react';
-import { type SearchableDropdownInstance, createEditableSelect } from '@grigoriev/react-sbb-polarion';
+import { type SearchableDropdownInstance, createEditableSelect } from '@sbb-polarion/react-sbb-polarion';
 
 /** Only Latin letters, upper-cased — matches the legacy ColumnInput sanitisation. */
 function sanitize(value: string): string {

--- a/ui/src/components/MappingRow.tsx
+++ b/ui/src/components/MappingRow.tsx
@@ -1,4 +1,4 @@
-import { SearchableSelect, type SelectOption } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect, type SelectOption } from '@sbb-polarion/react-sbb-polarion';
 import ColumnInput from './ColumnInput';
 
 /** One row of the column-to-field mapping table. A root row maps an Excel column to a work item

--- a/ui/src/components/OptionsMappingModal.tsx
+++ b/ui/src/components/OptionsMappingModal.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { Modal } from '@grigoriev/react-sbb-polarion';
+import { Modal } from '@sbb-polarion/react-sbb-polarion';
 import type { FieldMetadata } from '../types';
 
 interface OptionsMappingModalProps {

--- a/ui/src/main.tsx
+++ b/ui/src/main.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import { configureGenericModules } from '@grigoriev/react-sbb-polarion';
-import '@grigoriev/react-sbb-polarion/style.css';
+import { configureGenericModules } from '@sbb-polarion/react-sbb-polarion';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import App from './App';
 import './App.css';
 

--- a/ui/src/pages/About.tsx
+++ b/ui/src/pages/About.tsx
@@ -1,4 +1,4 @@
-import { About } from '@grigoriev/react-sbb-polarion';
+import { About } from '@sbb-polarion/react-sbb-polarion';
 import appIcon from '../assets/app-icon.svg';
 import useRemote from '../services/useRemote';
 

--- a/ui/src/pages/ImportFile.tsx
+++ b/ui/src/pages/ImportFile.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
-import { PageLayout } from '@grigoriev/react-sbb-polarion';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { PageLayout } from '@sbb-polarion/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import { getProjectIdFromScope, getScope } from '../services/scope';
 import useRemote from '../services/useRemote';
 import type { ImportResult, MappingName } from '../types';

--- a/ui/src/pages/Landing.tsx
+++ b/ui/src/pages/Landing.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { SearchableSelect } from '@grigoriev/react-sbb-polarion';
+import { SearchableSelect } from '@sbb-polarion/react-sbb-polarion';
 import { FEATURES } from '../features';
 import { getCookie, setCookie } from '../services/cookies';
 import { fetchProjects } from '../services/projects';

--- a/ui/src/pages/Mappings.tsx
+++ b/ui/src/pages/Mappings.tsx
@@ -7,7 +7,7 @@ import {
   RevisionsTable,
   SearchableSelect,
   useConfirm,
-} from '@grigoriev/react-sbb-polarion';
+} from '@sbb-polarion/react-sbb-polarion';
 import { toast } from 'sonner';
 import MappingRow from '../components/MappingRow';
 import type { MappingRowData } from '../components/MappingRow';

--- a/ui/src/pages/UserGuide.tsx
+++ b/ui/src/pages/UserGuide.tsx
@@ -1,4 +1,4 @@
-import { UserGuide } from '@grigoriev/react-sbb-polarion';
+import { UserGuide } from '@sbb-polarion/react-sbb-polarion';
 import useRemote from '../services/useRemote';
 
 /** Feeds the shared User Guide page this extension's REST hook. */

--- a/ui/src/types.ts
+++ b/ui/src/types.ts
@@ -22,7 +22,7 @@ export interface SettingName {
 
 // The Revision type is owned by react-sbb-polarion (used by its shared RevisionsTable); re-exported
 // here so this app's local imports (settings.ts, Mappings.tsx) keep a single `../types` source.
-export type { Revision } from '@grigoriev/react-sbb-polarion';
+export type { Revision } from '@sbb-polarion/react-sbb-polarion';
 
 /** One selectable option of an enum / test-steps field (generic fields.model.Option). */
 export interface FieldOption {

--- a/ui/test/setup.ts
+++ b/ui/test/setup.ts
@@ -8,6 +8,6 @@
 // github-markdown-light.css) are NOT bundled and are not loaded here; they are baseline chrome / help
 // article styling and do not materially affect the Mappings page (its config-pane + toolbar styling
 // now lives in react-sbb-polarion). Also registers jest-dom matchers.
-import '@grigoriev/react-sbb-polarion/style.css';
+import '@sbb-polarion/react-sbb-polarion/style.css';
 import '@testing-library/jest-dom/vitest';
 import '../src/App.css';

--- a/ui/vite.config.js
+++ b/ui/vite.config.js
@@ -5,7 +5,7 @@ export default defineConfig(({ command, mode }) => {
   const env = loadEnv(mode, process.cwd(), '');
   const polarionUrl = env.VITE_BASE_URL || 'http://localhost';
 
-  // The shared @grigoriev/react-sbb-polarion (RSP) package is linked via a `file:` dependency, which npm
+  // The shared @sbb-polarion/react-sbb-polarion (RSP) package is linked via a `file:` dependency, which npm
   // symlinks into node_modules together with its own dev copy of React. Dedupe so the app and the
   // linked library resolve to this app's single React instance (avoids the dual-React "invalid hook
   // call"). Harmless once the package is consumed from a registry instead of a symlink.

--- a/ui/vitest.config.ts
+++ b/ui/vitest.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
       'react/jsx-dev-runtime',
       'sonner',
       'vitest-browser-react',
-      '@grigoriev/react-sbb-polarion',
+      '@sbb-polarion/react-sbb-polarion',
     ],
   },
   test: {


### PR DESCRIPTION
The shared React library moved from a personal npm scope to the SBB organization and released 1.0.0:
`@grigoriev/react-sbb-polarion` is now
[`@sbb-polarion/react-sbb-polarion`](https://www.npmjs.com/package/@sbb-polarion/react-sbb-polarion).

Only the package name changes. 1.0.0 is 0.2.1 with a different name - the major is there because the
rename itself is the breaking change, not because the API moved. So this is the dependency, its version
range and every import, nothing else.

The stale `github.com/grigoriev/react-sbb-polarion` links follow the repository to
`SchweizerischeBundesbahnen`. `io.github.grigoriev` in `pom.xml` and `grigoriev/pre-commit-*` in
`.pre-commit-config.yaml` are unrelated projects and are left alone.
